### PR TITLE
Add admin login endpoint and session middleware

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const session = require('express-session');
 const cors = require('cors');
+const bcrypt = require('bcrypt');
 const db = require('./db');
 
 const app = express();
@@ -19,6 +20,42 @@ app.use(session({
   resave: false,
   saveUninitialized: false
 }));
+
+function isAdmin(req, res, next) {
+  if (req.session && req.session.admin) {
+    return next();
+  }
+  res.status(401).json({ error: 'Unauthorized' });
+}
+
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Missing credentials' });
+  }
+  db.get('SELECT password FROM admin WHERE username = ?', [username], (err, row) => {
+    if (err) {
+      return res.status(500).json({ error: 'Database error' });
+    }
+    if (!row) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    bcrypt.compare(password, row.password, (err, result) => {
+      if (err) {
+        return res.status(500).json({ error: 'Server error' });
+      }
+      if (!result) {
+        return res.status(401).json({ error: 'Invalid credentials' });
+      }
+      req.session.admin = true;
+      res.json({ message: 'Login successful' });
+    });
+  });
+});
+
+app.get('/api/admin', isAdmin, (req, res) => {
+  res.json({ message: 'Admin access granted' });
+});
 
 app.get('/', (req, res) => {
   res.send('Server running');


### PR DESCRIPTION
## Summary
- add POST /api/login to authenticate admin using bcrypt and persist session
- introduce isAdmin middleware and protect admin route

## Testing
- `npm test` *(fails: Missing script 'test')*
- `node server.js &` then `curl http://localhost:3000/api/login` (invalid and valid credentials)
- `curl http://localhost:3000/api/admin` (after login)

------
https://chatgpt.com/codex/tasks/task_e_68918fcf1d5c832a972b329f648b4976