### PR TITLE
Add templates endpoint with question images and options

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -25,6 +25,7 @@ db.serialize(() => {
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     template_id INTEGER,
     text TEXT,
+    image_url TEXT,
     FOREIGN KEY(template_id) REFERENCES templates(id)
   )`);
 


### PR DESCRIPTION
## Summary
- add POST /api/templates endpoint (admin only) to store templates, questions and options
- support question image URLs and option correctness flags

## Testing
- `npm test` *(fails: Missing script "test")*
- `node server.js` *(server started and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6891920afaf4832aa77fda58a288cc9a