### PR TITLE
feat: add basic game admin and report views

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,30 +1,6 @@
-<script setup>
-import HelloWorld from './components/HelloWorld.vue'
-</script>
-
 <template>
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="/vite.svg" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://vuejs.org/" target="_blank">
-      <img src="./assets/vue.svg" class="logo vue" alt="Vue logo" />
-    </a>
-  </div>
-  <HelloWorld msg="Vite + Vue" />
+  <router-view />
 </template>
 
-<style scoped>
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.vue:hover {
-  filter: drop-shadow(0 0 2em #42b883aa);
-}
-</style>
+<script setup>
+</script>

--- a/frontend/src/components/PlayerList.vue
+++ b/frontend/src/components/PlayerList.vue
@@ -1,0 +1,41 @@
+<template>
+  <div>
+    <h3>Players</h3>
+    <ul>
+      <li v-for="p in players" :key="p.id">{{ p.name }}</li>
+    </ul>
+    <button @click="loadPlayers">Refresh</button>
+    <button @click="clearPlayers">Clear</button>
+    <p v-if="error">{{ error }}</p>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import api from '../api'
+
+const players = ref([])
+const error = ref('')
+
+const loadPlayers = async () => {
+  error.value = ''
+  try {
+    const res = await api.get('/players', { withCredentials: true })
+    players.value = res.data
+  } catch (e) {
+    error.value = e.response?.data?.error || 'Failed to load players'
+  }
+}
+
+const clearPlayers = async () => {
+  error.value = ''
+  try {
+    await api.delete('/players', { withCredentials: true })
+    players.value = []
+  } catch (e) {
+    error.value = e.response?.data?.error || 'Failed to clear players'
+  }
+}
+
+onMounted(loadPlayers)
+</script>

--- a/frontend/src/components/TemplateForm.vue
+++ b/frontend/src/components/TemplateForm.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <h3>Upload Template</h3>
+    <form @submit.prevent="submitTemplate">
+      <input v-model="name" placeholder="Template name" />
+      <textarea v-model="json" placeholder="Questions JSON"></textarea>
+      <button type="submit">Submit</button>
+    </form>
+    <p v-if="message">{{ message }}</p>
+    <p v-if="error">{{ error }}</p>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import api from '../api'
+
+const name = ref('')
+const json = ref('')
+const message = ref('')
+const error = ref('')
+
+const submitTemplate = async () => {
+  message.value = ''
+  error.value = ''
+  try {
+    const payload = { name: name.value, questions: JSON.parse(json.value) }
+    await api.post('/templates', payload, { withCredentials: true })
+    message.value = 'Template saved'
+    name.value = ''
+    json.value = ''
+  } catch (e) {
+    error.value = e.response?.data?.error || 'Failed to save template'
+  }
+}
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,6 +1,16 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import Login from '../views/Login.vue'
+import PlayerJoin from '../views/PlayerJoin.vue'
+import AdminPanel from '../views/AdminPanel.vue'
+import Reports from '../views/Reports.vue'
 
-const routes = []
+const routes = [
+  { path: '/', redirect: '/join' },
+  { path: '/login', component: Login },
+  { path: '/join', component: PlayerJoin },
+  { path: '/admin', component: AdminPanel },
+  { path: '/reports', component: Reports }
+]
 
 const router = createRouter({
   history: createWebHistory(),

--- a/frontend/src/views/AdminPanel.vue
+++ b/frontend/src/views/AdminPanel.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>
+    <h2>Admin Panel</h2>
+    <PlayerList />
+    <TemplateForm />
+  </div>
+</template>
+
+<script setup>
+import PlayerList from '../components/PlayerList.vue'
+import TemplateForm from '../components/TemplateForm.vue'
+</script>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -1,0 +1,32 @@
+<template>
+  <div>
+    <h2>Admin Login</h2>
+    <form @submit.prevent="login">
+      <input v-model="username" placeholder="Username" />
+      <input v-model="password" type="password" placeholder="Password" />
+      <button type="submit">Login</button>
+    </form>
+    <p v-if="error">{{ error }}</p>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import api from '../api'
+
+const username = ref('')
+const password = ref('')
+const error = ref('')
+const router = useRouter()
+
+const login = async () => {
+  error.value = ''
+  try {
+    await api.post('/login', { username: username.value, password: password.value }, { withCredentials: true })
+    router.push('/admin')
+  } catch (e) {
+    error.value = e.response?.data?.error || 'Login failed'
+  }
+}
+</script>

--- a/frontend/src/views/PlayerJoin.vue
+++ b/frontend/src/views/PlayerJoin.vue
@@ -1,0 +1,32 @@
+<template>
+  <div>
+    <h2>Join Game</h2>
+    <form @submit.prevent="join">
+      <input v-model="name" placeholder="Your name" />
+      <button type="submit">Join</button>
+    </form>
+    <p v-if="message">{{ message }}</p>
+    <p v-if="error">{{ error }}</p>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import api from '../api'
+
+const name = ref('')
+const message = ref('')
+const error = ref('')
+
+const join = async () => {
+  message.value = ''
+  error.value = ''
+  try {
+    const res = await api.post('/player', { name: name.value })
+    message.value = `Player ${res.data.name} joined with id ${res.data.id}`
+    name.value = ''
+  } catch (e) {
+    error.value = e.response?.data?.error || 'Join failed'
+  }
+}
+</script>

--- a/frontend/src/views/Reports.vue
+++ b/frontend/src/views/Reports.vue
@@ -1,0 +1,52 @@
+<template>
+  <div>
+    <h2>Reports</h2>
+    <div>
+      <h3>Top Players</h3>
+      <table>
+        <tr><th>Player</th><th>Correct Answers</th></tr>
+        <tr v-for="p in topPlayers" :key="p.id">
+          <td>{{ p.name }}</td>
+          <td>{{ p.correct_answers }}</td>
+        </tr>
+      </table>
+    </div>
+    <div>
+      <h3>Question Stats</h3>
+      <table>
+        <tr><th>Question</th><th>Total Responses</th><th>Correct</th></tr>
+        <tr v-for="q in questionStats" :key="q.id">
+          <td>{{ q.text }}</td>
+          <td>{{ q.total_responses }}</td>
+          <td>{{ q.correct_responses }}</td>
+        </tr>
+      </table>
+    </div>
+    <p v-if="error">{{ error }}</p>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import api from '../api'
+
+const topPlayers = ref([])
+const questionStats = ref([])
+const error = ref('')
+
+const load = async () => {
+  error.value = ''
+  try {
+    const [playersRes, questionsRes] = await Promise.all([
+      api.get('/report/top-players', { withCredentials: true }),
+      api.get('/report/questions', { withCredentials: true })
+    ])
+    topPlayers.value = playersRes.data
+    questionStats.value = questionsRes.data
+  } catch (e) {
+    error.value = e.response?.data?.error || 'Failed to load reports'
+  }
+}
+
+onMounted(load)
+</script>


### PR DESCRIPTION
## Summary
- add login and player join views
- implement admin panel for managing players and templates
- display top player and question reports

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run build`
- `npm test` (backend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689194b43390832a89fc9f0c50c45ad2