### PR TITLE
Serve frontend build and document setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,22 @@
 - `POST /api/responses` guarda las respuestas de los jugadores recibiendo `player_id`, `question_id` e `is_correct`.
 - `GET /api/report/top-players` devuelve el ranking de jugadores por respuestas correctas.
 - `GET /api/report/questions` entrega estadísticas de respuestas por pregunta.
+
+## Ejecución
+
+1. En el frontend:
+
+   ```bash
+   cd frontend
+   npm install
+   npm run build
+   ```
+
+2. En el backend:
+
+   ```bash
+   cd ../backend
+   npm install
+   npm start
+   ```
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const session = require('express-session');
 const cors = require('cors');
 const bcrypt = require('bcrypt');
+const path = require('path');
 const db = require('./db');
 
 const app = express();
@@ -219,8 +220,11 @@ app.get('/api/admin', isAdmin, (req, res) => {
   res.json({ message: 'Admin access granted' });
 });
 
-app.get('/', (req, res) => {
-  res.send('Server running');
+const distPath = path.join(__dirname, '../frontend/dist');
+app.use(express.static(distPath));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(distPath, 'index.html'));
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- Serve built frontend assets from `frontend/dist` using Express and handle SPA routes by returning `index.html`.
- Document how to install dependencies, build the frontend, and start the backend.

## Testing
- `cd backend && npm test` *(fails: Missing script: "test")*
- `cd frontend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689195cc1540832aaf0f95dbb170f747